### PR TITLE
feat: 대기열 시스템 기능 확장 및 테스트 코드 구현

### DIFF
--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	// Spring Boot Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
+	// Embedded Redis
+	testImplementation 'com.github.codemonstur:embedded-redis:1.0.0'
 }
 
 tasks.named('test') {

--- a/flow/src/main/java/com/fastcampus/flow/controller/UserQueueController.java
+++ b/flow/src/main/java/com/fastcampus/flow/controller/UserQueueController.java
@@ -1,10 +1,13 @@
 package com.fastcampus.flow.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fastcampus.flow.dto.AllowUserResponse;
+import com.fastcampus.flow.dto.AllowedUserResponse;
 import com.fastcampus.flow.dto.RegisterUserResponse;
 import com.fastcampus.flow.service.UserQueueService;
 
@@ -23,5 +26,21 @@ public class UserQueueController {
         @RequestParam(name = "user_id") Long userId
     ) {
         return userQueueService.registerWaitQueue(queue, userId).map(RegisterUserResponse::new);
+    }
+
+    @PostMapping("/allow")
+    public Mono<AllowUserResponse> allowUser(
+        @RequestParam(name = "queue", defaultValue = "default") String queue,
+        @RequestParam(name = "count") Long count
+    ) {
+        return userQueueService.allowUser(queue, count).map(allowed -> new AllowUserResponse(count, allowed));
+    }
+
+    @GetMapping("/allowed")
+    public Mono<AllowedUserResponse> isAllowedUser(
+        @RequestParam(name = "queue", defaultValue = "default") String queue,
+        @RequestParam(name = "user_id") Long userId
+    ) {
+        return userQueueService.isAllowed(queue, userId).map(AllowedUserResponse::new);
     }
 }

--- a/flow/src/main/java/com/fastcampus/flow/dto/AllowUserResponse.java
+++ b/flow/src/main/java/com/fastcampus/flow/dto/AllowUserResponse.java
@@ -1,0 +1,8 @@
+package com.fastcampus.flow.dto;
+
+public record AllowUserResponse(
+    Long requestCount, 
+    Long allowedCount
+) {
+    
+}

--- a/flow/src/main/java/com/fastcampus/flow/dto/AllowedUserResponse.java
+++ b/flow/src/main/java/com/fastcampus/flow/dto/AllowedUserResponse.java
@@ -1,0 +1,7 @@
+package com.fastcampus.flow.dto;
+
+public record AllowedUserResponse(
+    Boolean allowed
+) {
+    
+}

--- a/flow/src/main/java/com/fastcampus/flow/service/UserQueueService.java
+++ b/flow/src/main/java/com/fastcampus/flow/service/UserQueueService.java
@@ -15,6 +15,7 @@ import reactor.core.publisher.Mono;
 public class UserQueueService {
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
     private final String USER_QUEUE_WAIT_KEY = "users:queue:%s:wait";
+    private final String USER_QUEUE_PROCEED_KEY = "users:queue:%s:proceed";
 
     public Mono<Long> registerWaitQueue(final String queue, final Long userId) {
         var unixTimestamp = Instant.now().getEpochSecond(); // 여기서 현재 시간을 초 단위로 가져온다.
@@ -22,10 +23,22 @@ public class UserQueueService {
                 .add(USER_QUEUE_WAIT_KEY.formatted(queue), userId.toString(), unixTimestamp) // 이 시점에서는 true/false를 반환하게 되는데 3번째 인자는 스코어 값이 double로 받기 때문에
                 .filter(i -> i) // 성공한 경우에대해서만 filter
                 .switchIfEmpty(Mono.error(ErrorCode.QUEUE_ALREADY_REGISTERED_USER.build())) // 실패한 경우에는 예외 처리
-                .flatMap(i -> reactiveRedisTemplate.opsForZSet().rank(
-                    USER_QUEUE_WAIT_KEY.formatted(queue),
-                    userId.toString()
-                )) // 성공에 대한 내용에 대해서 랭크를 가져오고
+                .flatMap(i -> reactiveRedisTemplate.opsForZSet().rank(USER_QUEUE_WAIT_KEY.formatted(queue), userId.toString())) // 성공에 대한 내용에 대해서 랭크를 가져오고
                 .map(i -> i >= 0 ? i + 1 : i); // 랭크가 0보다 크거나 같으면 1을 더해주고, 아니면 그대로 반환
+    }
+
+    public Mono<Long> allowUser(final String queue, final Long count) {
+        return reactiveRedisTemplate.opsForZSet().popMin(USER_QUEUE_WAIT_KEY.formatted(queue), count)
+                .flatMap(member -> reactiveRedisTemplate.opsForZSet().add(
+                    USER_QUEUE_PROCEED_KEY.formatted(queue),
+                    member.getValue(), Instant.now().getEpochSecond()
+                ))
+                .count();
+    }
+
+    public Mono<Boolean> isAllowed(final String queue, final Long userId) {
+        return reactiveRedisTemplate.opsForZSet().rank(USER_QUEUE_PROCEED_KEY.formatted(queue), userId.toString())
+                .defaultIfEmpty(-1L)
+                .map(rank -> rank >= 0);
     }
 }

--- a/flow/src/main/resources/application.yml
+++ b/flow/src/main/resources/application.yml
@@ -6,3 +6,14 @@ spring:
     redis:
       host: 127.0.0.1
       port: 6379
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 63790
+      

--- a/flow/src/test/java/com/fastcampus/flow/EmbeddedRedis.java
+++ b/flow/src/test/java/com/fastcampus/flow/EmbeddedRedis.java
@@ -1,0 +1,28 @@
+package com.fastcampus.flow;
+
+import java.io.IOException;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import redis.embedded.RedisServer;
+
+@TestConfiguration
+public class EmbeddedRedis {
+    private final RedisServer redisServer;
+
+    public EmbeddedRedis() throws IOException {
+        this.redisServer = new RedisServer(63790);
+    }
+
+    @PostConstruct
+    public void start() throws IOException {
+        this.redisServer.start();
+    }
+
+    @PreDestroy
+    public void stop() throws IOException {
+        this.redisServer.stop();
+    }
+}

--- a/flow/src/test/java/com/fastcampus/flow/service/UserQueueServiceTest.java
+++ b/flow/src/test/java/com/fastcampus/flow/service/UserQueueServiceTest.java
@@ -1,0 +1,121 @@
+package com.fastcampus.flow.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.fastcampus.flow.EmbeddedRedis;
+import com.fastcampus.flow.exception.ApplicationException;
+
+import reactor.test.StepVerifier;
+
+@SpringBootTest
+@Import(EmbeddedRedis.class)
+@ActiveProfiles("test")
+public class UserQueueServiceTest {
+    @Autowired
+    private UserQueueService userQueueService;
+
+    @Autowired
+    private ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+    @BeforeEach
+    public void beforeEach() {
+        ReactiveRedisConnection redisConnection = reactiveRedisTemplate.getConnectionFactory().getReactiveConnection();
+        redisConnection.serverCommands().flushAll().subscribe();
+    }
+
+    @Test
+    void registerWaitQueue() {
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 100L))
+                .expectNext(1L)
+                .verifyComplete();
+
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 101L))
+                .expectNext(2L)
+                .verifyComplete();
+
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 102L))
+                .expectNext(3L)
+                .verifyComplete();
+    }
+
+    @Test
+    void alreadyRegisterWaitQueue() {
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 100L))
+                .expectNext(1L)
+                .verifyComplete();
+
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 100L))
+                .expectError(ApplicationException.class)
+                .verify();
+    }
+
+    @Test
+    void emptyAllowUser() {
+        StepVerifier.create(userQueueService.allowUser("default", 3L))
+                .expectNext(0L)
+                .verifyComplete();
+    }
+
+    @Test
+    void allowUser() {
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 100L)
+                .then(userQueueService.registerWaitQueue("default", 101L))
+                .then(userQueueService.registerWaitQueue("default", 102L))
+                .then(userQueueService.allowUser("default", 2L)))
+                .expectNext(2L)
+                .verifyComplete();
+    }
+
+    @Test
+    void allowUser2() {
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 100L)
+                .then(userQueueService.registerWaitQueue("default", 101L))
+                .then(userQueueService.registerWaitQueue("default", 102L))
+                .then(userQueueService.allowUser("default", 5L)))
+                .expectNext(3L)
+                .verifyComplete();
+    }
+
+    @Test
+    void allowUserAfterRegisterWaitQueue() {
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 100L)
+                .then(userQueueService.registerWaitQueue("default", 101L))
+                .then(userQueueService.registerWaitQueue("default", 102L))
+                .then(userQueueService.allowUser("default", 3L))
+                .then(userQueueService.registerWaitQueue("default", 200L)))
+                .expectNext(1L)
+                .verifyComplete();
+    }
+
+    @Test
+    void isNotAllowed() {
+        StepVerifier.create(userQueueService.isAllowed("default", 100L))
+                .expectNext(false)
+                .verifyComplete();
+    }
+
+    @Test
+    void isNotAllowed2() {
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 100L)
+                .then(userQueueService.allowUser("default", 3L))
+                .then(userQueueService.isAllowed("default", 101L)))
+                .expectNext(false)
+                .verifyComplete();
+    }
+
+    @Test
+    void isAllowed() {
+        StepVerifier.create(userQueueService.registerWaitQueue("default", 100L)
+                .then(userQueueService.allowUser("default", 3L))
+                .then(userQueueService.isAllowed("default", 100L)))
+                .expectNext(true)
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes: #4
## ✅ 주요 작업 내용

- [x] 사용자 대기열에서 허용 처리하는 API 구현 (/api/v1/queue/allow)
- [x] 사용자 입장 허용 여부 확인 API 구현 (/api/v1/queue/allowed)
- [x] 사용자 대기열에서 허용 목록으로 이동 처리 로직 구현
- [x] 응답용 DTO 클래스 추가 (AllowUserResponse, AllowedUserResponse)
- [x] 테스트 환경 구성 (EmbeddedRedis, 테스트 프로필)
- [x] UserQueueService에 대한 테스트 코드 작성

## 🤔 작업 배경 및 고민 과정
사용자 대기열 등록 기능만으로는 실제 서비스 입장 흐름을 제어할 수 없어 추가 기능이 필요했습니다. Redis의 Sorted Set을 사용하여 대기열에서 허용 목록으로 사용자를 이동시키는 방식으로 구현했으며, 이를 통해 서비스 부하를 분산시키고 안정적인 사용자 경험을 제공할 수 있게 되었습니다. 또한 테스트 자동화를 위해 EmbeddedRedis를 활용한 테스트 환경을 구성했습니다.

## ✨ 셀프 리뷰 체크리스트
x

## 🖼️ 스크린샷 (필요시)

<img src="파일 주소" width="50%" height="50%">
<br/>

## 💡 추가 전달 사항